### PR TITLE
Fix ArksEndpoint controller to support ArksDisaggregatedApplication service discovery

### DIFF
--- a/internal/controller/arksendpoint_controller.go
+++ b/internal/controller/arksendpoint_controller.go
@@ -416,20 +416,27 @@ func (r *ArksEndpointReconciler) reconcile(ctx context.Context, ep *arksv1.ArksE
 	return ctrl.Result{}, nil
 }
 
-func getArksEndpointNameFromApplication(obj client.Object) string {
-	if obj == nil {
-		return ""
-	}
-	app, ok := obj.(*arksv1.ArksApplication)
-	if !ok {
-		return ""
-	}
-	if app.Spec.ServedModelName == "" {
-		return app.Spec.Model.Name
-	}
+  func getArksEndpointNameFromApplication(obj client.Object) string {
+        if obj == nil {
+                return ""
+        }
 
-	return app.Spec.ServedModelName
-}
+        if app, ok := obj.(*arksv1.ArksApplication); ok {
+                if app.Spec.ServedModelName == "" {
+                        return app.Spec.Model.Name
+                }
+                return app.Spec.ServedModelName
+        }
+
+        if app, ok := obj.(*arksv1.ArksDisaggregatedApplication); ok {
+                if app.Spec.ServedModelName == "" {
+                        return app.Spec.Model.Name
+                }
+                return app.Spec.ServedModelName
+        }
+
+        return ""
+  }
 
 func isArksApplicationReady(obj client.Object) bool {
 	if obj == nil {


### PR DESCRIPTION
Fixes #56 

## Summary

This PR fixes two bugs in ArksEndpoint controller that prevent ArksDisaggregatedApplication from being discovered and added to HTTPRoute backendRefs, causing Gateway routing failures.

## Problem

ArksDisaggregatedApplication deployments cannot be accessed through Gateway API because HTTPRoute backendRefs are not generated. This affects all PD separation architecture deployments while ArksApplication (monolithic) works correctly.

## Root Cause

1. **IndexFunc type assertion error**: `ArksAppIndexFunc` only handles `*arksv1.ArksApplication`, returning `nil` for `*arksv1.ArksDisaggregatedApplication`, breaking FieldIndexer
2. **Service naming mismatch**: Controller expects `{app.Name}-router-svc` but actual Service is `arks-application-{app.Name}`

## Changes

### File: `internal/controller/arksendpoint_controller.go`

**1. Fix IndexFunc to handle both Application types (line 51-66)**

Before:
```go
func (r *ArksEndpointReconciler) ArksAppIndexFunc(obj client.Object) []string {
    app, ok := obj.(*arksv1.ArksApplication)
    if !ok {
        return nil
    }
    if app.Spec.ServedModelName == "" {
        return []string{app.Spec.Model.Name}
    }
    return []string{app.Spec.ServedModelName}
}
```

After:
```go
func (r *ArksEndpointReconciler) ArksAppIndexFunc(obj client.Object) []string {
    // Handle ArksApplication
    if app, ok := obj.(*arksv1.ArksApplication); ok {
        if app.Spec.ServedModelName == "" {
            return []string{app.Spec.Model.Name}
        }
        return []string{app.Spec.ServedModelName}
    }

    // Handle ArksDisaggregatedApplication
    if app, ok := obj.(*arksv1.ArksDisaggregatedApplication); ok {
        if app.Spec.ServedModelName == "" {
            return []string{app.Spec.Model.Name}
        }
        return []string{app.Spec.ServedModelName}
    }

    return nil
}
```

**2. Fix Service naming for ArksDisaggregatedApplication (line 313)**

Before:
```go
for _, app := range disAppList.Items {
    svcName := fmt.Sprintf("%s-router-svc", app.Name)  // Wrong format
    // ...
}
```

After:
```go
for _, app := range disAppList.Items {
    svcName := getApplicationServiceName(app.Name)  // Use consistent naming
    // ...
}
```

This uses the existing `getApplicationServiceName()` helper function (line 462-464) that generates the correct format `arks-application-{app.Name}`, matching the actual Service created by ArksDisaggregatedApplication Controller.

## Testing

### Test Environment
- Kubernetes v1.28.2
- ArksModel: qwen3-7b
- Gateway: Envoy Gateway (arks-eg)

### Test Setup

Created two Applications using the same model to verify both architectures work:

1. ArksDisaggregatedApplication (PD separation):
```yaml
apiVersion: arks.ai/v1
kind: ArksDisaggregatedApplication
metadata:
  name: test-disagg
spec:
  model:
    name: qwen3-7b
  router:
    replicas: 1
  prefill:
    replicas: 1
    size: 1
  decode:
    replicas: 1
    size: 1
```

2. ArksApplication (monolithic):
```yaml
apiVersion: arks.ai/v1
kind: ArksApplication
metadata:
  name: test-app
spec:
  model:
    name: qwen3-7b
  replicas: 1
  size: 1
```

### Test Results

**Before fix:**
```bash
$ kubectl get httproute qwen3-7b -n default -o jsonpath='{.spec.rules[0].backendRefs}'
# Empty or only contains ArksApplication
```

**After fix:**
```bash
$ kubectl get httproute qwen3-7b -n default -o jsonpath='{.spec.rules[0].backendRefs[*].name}'
arks-application-test-app arks-application-test-disagg

$ kubectl get httproute qwen3-7b -n default -o jsonpath='{.spec.rules[0].backendRefs}' | jq
[
  {
    "group": "",
    "kind": "Service",
    "name": "arks-application-test-app",
    "port": 8080,
    "weight": 1
  },
  {
    "group": "",
    "kind": "Service",
    "name": "arks-application-test-disagg",
    "port": 8080,
    "weight": 1
  }
]
```

**Operator logs confirm:**
```
application service default/test-disagg added in http route
```

**Gateway access test:**
```bash
$ curl -X POST http://gateway/v1/chat/completions \
  -H 'Authorization: Bearer <token>' \
  -H 'namespace: default' \
  -H 'model: qwen3-7b' \
  -d '{"model":"qwen3-7b","messages":[{"role":"user","content":"test"}]}'

# Returns: Normal JSON response (not 500 error)
{"id":"...","object":"chat.completion","choices":[...],"usage":{...}}
```

### Backward Compatibility

- ArksApplication continues to work correctly
- Both Application types can coexist and are added to the same HTTPRoute backendRefs
- No breaking changes to API or user configuration

## Checklist

- [ ] Code follows project style guidelines
- [ ] Changes tested locally with both Application types
- [ ] HTTPRoute backendRefs correctly generated for ArksDisaggregatedApplication
- [ ] HTTPRoute backendRefs still work for ArksApplication (backward compatible)
- [ ] Gateway routing works for both architectures
- [ ] Operator logs confirm service discovery
- [ ] No breaking changes
