### PR TITLE
Fixes Service creation logic issue 

### DIFF
--- a/internal/controller/arksapplication_controller.go
+++ b/internal/controller/arksapplication_controller.go
@@ -117,6 +117,7 @@ func (r *ArksApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&arksv1.ArksApplication{}).
 		Named("arksapplication").
 		Owns(&lwsapi.LeaderWorkerSet{}).
+		Owns(&corev1.Service{}).
 		Complete(r)
 }
 
@@ -277,53 +278,52 @@ func (r *ArksApplicationReconciler) reconcile(ctx context.Context, application *
 			}
 		}
 
-		// check service
-		serviceName := generateApplicationServiceName(application)
-		if _, err := r.KubeClient.CoreV1().Services(application.Namespace).Get(ctx, serviceName, metav1.GetOptions{}); err != nil {
-			if apierrors.IsNotFound(err) {
-				svc := &corev1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: application.Namespace,
-						Name:      serviceName,
-						Labels: map[string]string{
-							"prometheus-discovery": "true",
-							"managed-by":           "arks",
-						},
-					},
-					Spec: corev1.ServiceSpec{
-						Selector: map[string]string{
-							arksv1.ArksControllerKeyApplication:  application.Name,
-							arksv1.ArksControllerKeyWorkLoadRole: arksv1.ArksWorkLoadRoleLeader,
-						},
-						Ports: []corev1.ServicePort{
-							{
-								Protocol: corev1.ProtocolTCP,
-								Port:     8080,
-								Name:     "http",
-							},
-						},
-					},
-				}
-				ctrl.SetControllerReference(application, svc, r.Scheme)
-
-				if _, err := r.KubeClient.CoreV1().Services(application.Namespace).Create(ctx, svc, metav1.CreateOptions{}); err != nil {
-					if !apierrors.IsAlreadyExists(err) {
-						klog.Errorf("application %s/%s: failed to create application service: %q", application.Namespace, application.Name, err)
-						return ctrl.Result{}, fmt.Errorf("failed to create application service: %q", err)
-					}
-				}
-				klog.Infof("application %s/%s: create application service successfully", application.Namespace, application.Name)
-			} else {
-				klog.Errorf("application %s/%s: failed to check the service: %q", application.Namespace, application.Name, err)
-				return ctrl.Result{}, fmt.Errorf("failed to check the service: %q", err)
-			}
-		}
-
 		application.Status.Phase = string(arksv1.ArksApplicationPhaseRunning)
 		updateApplicationCondition(application, arksv1.ArksApplicationReady, corev1.ConditionTrue, "Running", "The LLM service is running")
 		klog.Infof("application %s/%s: create underlying LWS successfully", application.Namespace, application.Name)
 	}
 
+	// ensure service exists 
+	serviceName := generateApplicationServiceName(application)
+	if _, err := r.KubeClient.CoreV1().Services(application.Namespace).Get(ctx, serviceName, metav1.GetOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: application.Namespace,
+					Name:      serviceName,
+					Labels: map[string]string{
+						"prometheus-discovery": "true",
+						"managed-by":           "arks",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Selector: map[string]string{
+						arksv1.ArksControllerKeyApplication:  application.Name,
+						arksv1.ArksControllerKeyWorkLoadRole: arksv1.ArksWorkLoadRoleLeader,
+					},
+					Ports: []corev1.ServicePort{
+						{
+							Protocol: corev1.ProtocolTCP,
+							Port:     8080,
+							Name:     "http",
+						},
+					},
+				},
+			}
+			ctrl.SetControllerReference(application, svc, r.Scheme)
+
+			if _, err := r.KubeClient.CoreV1().Services(application.Namespace).Create(ctx, svc, metav1.CreateOptions{}); err != nil {
+				if !apierrors.IsAlreadyExists(err) {
+					klog.Errorf("application %s/%s: failed to ensure service exists: %v", application.Namespace, application.Name, err)
+					return ctrl.Result{}, fmt.Errorf("failed to ensure service exists: %w", err)
+				}
+			}
+			klog.Infof("application %s/%s: service created successfully", application.Namespace, application.Name)
+		} else {
+			klog.Errorf("application %s/%s: failed to check service: %v", application.Namespace, application.Name, err)
+			return ctrl.Result{}, fmt.Errorf("failed to check service: %w", err)
+		}
+	}
 	// sync status
 	if lws, err := r.LWSClient.LeaderworkersetV1().LeaderWorkerSets(application.Namespace).Get(ctx, application.Name, metav1.GetOptions{}); err != nil {
 		if !apierrors.IsNotFound(err) {


### PR DESCRIPTION
## Description

Fixes Service creation logic issue where Services are not recreated after Application becomes Ready.

Service creation logic was inside the Ready condition block, causing Services to never be checked or recreated in subsequent reconciles after Application becomes Ready. This PR moves Service creation outside the condition block and adds Service to owned resources for automatic reconcile on deletion.

Fixes #58 

## Problem

**Affected Controllers:**
- ArksApplication Controller
- ArksDisaggregatedApplication Controller

**Issue:**
Service creation code is inside the Ready condition block. Once Application is marked Ready, Service creation code is skipped in all subsequent reconciles.

**Impact:**
- Service creation failures leave Service permanently missing
- Deleted Services are not recreated
- Application shows Ready but requests fail
- Manual intervention required to restore Service

## Root Cause

Service creation is inside Ready condition block:

```go
if !checkApplicationCondition(application, Ready) {
    // Create LWS
    // Create Service  // Only executed when Ready=False
    // Set Ready=True
}
// When Ready=True, entire block skipped
```

Additionally, Controllers do not watch Service resources, so Service deletion does not trigger reconcile.

## Solution

**1. Move Service creation outside Ready condition block**

```go
if !checkApplicationCondition(application, Ready) {
    // Create LWS
    // Set Ready
}

// Service creation runs on every reconcile
serviceName := generateApplicationServiceName(application)
if _, err := r.KubeClient.CoreV1().Services(...).Get(...); err != nil {
    if apierrors.IsNotFound(err) {
        // Create Service
    }
}
```

**2. Add Service to owned resources**

```go
func (r *ArksApplicationReconciler) SetupWithManager(mgr ctrl.Manager) error {
    return ctrl.NewControllerManagedBy(mgr).
        For(&arksv1.ArksApplication{}).
        Owns(&lwsapi.LeaderWorkerSet{}).
        Owns(&corev1.Service{}).  // Add this line
        Complete(r)
}
```

This ensures:
- Service existence checked on every reconcile
- Service deletion automatically triggers reconcile
- Service recreated within 30 seconds without manual intervention

## Changes

### Files Modified

**1. `internal/controller/arksapplication_controller.go`**
- Removed Service creation from lines 291-331 (inside Ready condition)
- Added Service creation after line 336 (outside Ready condition)
- Added `.Owns(&corev1.Service{})` to SetupWithManager (line 119)

**2. `internal/controller/arksdisaggregatedapplication_controller.go`**
- Removed Router Service creation from lines 348-358 (inside Ready condition)
- Added Router Service creation after line 364 (outside Ready condition)
- Added `.Owns(&corev1.Service{})` to SetupWithManager (line 491)

## Testing

### Test Environment

- Kubernetes cluster: v1.28+
- Image: `registry-ap-southeast.scitix.ai/k8s/arks-operator:service-fix-3554376`
- Test Application: ArksApplication with Qwen3-7B model

### Test Results

**Test 1: Service Auto-Recreation**

```bash
# Delete Service
kubectl delete svc arks-application-test-arksapp-qwen3-7b

# Wait 30 seconds (no manual trigger needed)
sleep 30

# Result: PASSED
kubectl get svc arks-application-test-arksapp-qwen3-7b
# NAME                                     TYPE        CLUSTER-IP      PORT(S)    AGE
# arks-application-test-arksapp-qwen3-7b   ClusterIP                        30s
```

**Controller Log:**
```
I1024 06:35:44.379955 1 arksapplication_controller.go:331] application default/test-arksapp-qwen3-7b: service created successfully
```

**Test 2: Multiple Deletion Cycles**

Three consecutive deletion tests - all Services recreated within 30 seconds automatically.

**Test 3: Service Configuration**

Verified:
- Selector contains correct labels (`arks.ai/application`, `arks.ai/work-load-role`)
- OwnerReferences correctly set to ArksApplication
- Endpoints correctly populated with Pod IP

**Test 4: Regression Testing**

- Existing Applications continue to work normally
- Application creation/update/deletion workflows unaffected
- LWS creation and management working correctly
- No performance impact on reconcile

### Test Summary

All tests passed:
- Service auto-recreation: PASSED
- Multiple deletion cycles: PASSED (3/3)
- Service configuration: PASSED
- Regression tests: PASSED

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex logic
- [ ] No new warnings generated
- [ ] Manual testing performed
- [ ] Regression testing completed
- [ ] No breaking changes introduced
